### PR TITLE
Adding Treeholes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,9 +52,9 @@ dependencies {
     includeModApi(kotlin("stdlib-jdk8", kotlinVersion))
     includeModApi(kotlin("stdlib-jdk7", kotlinVersion))
     includeModApi(kotlin("reflect", kotlinVersion))
-    includeModApi("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0")
-    includeModApi("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.0")
-    includeModApi("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.0")
+    includeModApi("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
+    includeModApi("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.1")
+    includeModApi("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.1")
 }
 
 tasks {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,13 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.warning.mode=all
 # Check these on https://fabricmc.net/versions.html
 minecraftVersion=1.18.2
-yarnMappings=1.18.2+build.1
+yarnMappings=1.18.2+build.3
 loaderVersion=0.13.3
 # Fabric API
-fabricVersion=0.47.8+1.18.2
+fabricVersion=0.50.0+1.18.2
 # Mod Properties
 modVersion=1.0.0
 mavenGroup=org.llamarama
 archivesBaseName=petty
 # Kotlin
-systemProp.kotlinVersion=1.6.0
+systemProp.kotlinVersion=1.6.20

--- a/src/main/java/org/llamarama/petty/mixins/ConfiguredFeaturesMixin.java
+++ b/src/main/java/org/llamarama/petty/mixins/ConfiguredFeaturesMixin.java
@@ -1,0 +1,37 @@
+package org.llamarama.petty.mixins;
+
+import net.minecraft.world.gen.feature.TreeConfiguredFeatures;
+import net.minecraft.world.gen.feature.TreeFeatureConfig;
+import net.minecraft.world.gen.treedecorator.BeehiveTreeDecorator;
+import net.minecraft.world.gen.treedecorator.TreeDecorator;
+import org.llamarama.petty.worldgen.decorators.TreeHoleDecorator;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.List;
+
+// This mixin is only for debug purposes
+@Deprecated()
+@Mixin(TreeConfiguredFeatures.class)
+public class ConfiguredFeaturesMixin {
+
+    /**
+     * Debug method to replace existing bee decorators with the custom TreeHoleDecorator
+     * In the future, we want to change this to ADD the TreeHole decorator to the list
+     * of decorators instead of replacing it
+     */
+    @Redirect(
+            method = "<clinit>",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/gen/feature/TreeFeatureConfig$Builder;decorators(Ljava/util/List;)Lnet/minecraft/world/gen/feature/TreeFeatureConfig$Builder;"
+            )
+    )
+    private static TreeFeatureConfig.Builder proxyDebug(TreeFeatureConfig.Builder builder, List<TreeDecorator> decorators) {
+        if (decorators.size() > 0 && decorators.get(0) instanceof BeehiveTreeDecorator) {
+            return builder.decorators(List.of(new TreeHoleDecorator()));
+        }
+        return builder.decorators(decorators);
+    }
+}

--- a/src/main/java/org/llamarama/petty/mixins/TreeDecoratorTypeMixin.java
+++ b/src/main/java/org/llamarama/petty/mixins/TreeDecoratorTypeMixin.java
@@ -1,0 +1,16 @@
+package org.llamarama.petty.mixins;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.world.gen.treedecorator.TreeDecorator;
+import net.minecraft.world.gen.treedecorator.TreeDecoratorType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(TreeDecoratorType.class)
+public interface TreeDecoratorTypeMixin {
+
+    @Invoker
+    static <P extends TreeDecorator> TreeDecoratorType<P> callRegister(String id, Codec<P> codec) {
+        throw new IllegalStateException("This method should never be called");
+    }
+}

--- a/src/main/kotlin/org/llamarama/petty/MainFile.kt
+++ b/src/main/kotlin/org/llamarama/petty/MainFile.kt
@@ -1,8 +1,9 @@
 package org.llamarama.petty
 
-import org.llamarama.petty.blocks.ModIdBlocks
-import org.llamarama.petty.items.ModIdItems
+import org.llamarama.petty.blocks.PettyBlocks
+import org.llamarama.petty.items.PettyItems
 import net.fabricmc.api.ModInitializer
+import org.llamarama.petty.worldgen.decorators.DecoratorTypes
 
 
 /**
@@ -17,7 +18,8 @@ object MainFile : ModInitializer {
 
 
     override fun onInitialize() {
-        ModIdBlocks.registerBlocks()
-        ModIdItems.registerItems()
+        PettyBlocks.registerBlocks()
+        PettyItems.registerItems()
+        DecoratorTypes
     }
 }

--- a/src/main/kotlin/org/llamarama/petty/blocks/PettyBlocks.kt
+++ b/src/main/kotlin/org/llamarama/petty/blocks/PettyBlocks.kt
@@ -2,8 +2,8 @@
 
 package org.llamarama.petty.blocks
 
-import org.llamarama.petty.MainFile
 import net.minecraft.block.AbstractBlock
+import org.llamarama.petty.MainFile
 import net.minecraft.block.Block
 import net.minecraft.block.Blocks
 import net.minecraft.item.BlockItem
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemGroup
 import net.minecraft.util.Identifier
 import net.minecraft.util.registry.Registry
 
-object ModIdBlocks {
+object PettyBlocks {
     private val BlockItemsRegistry = linkedMapOf<String, Item>()
     private val BlockRegistry = linkedMapOf<String, Block>()
 
@@ -27,7 +27,7 @@ object ModIdBlocks {
         COOL_BLOCK = addBlock("coolblock", Block(AbstractBlock.Settings.copy(Blocks.STONE)))
     }
 
-    private fun <B: Block> addBlock(name: String, block: B): B {
+    private fun  addBlock(name: String, block: Block): Block {
         val correctedName = name.replace(" ", "").lowercase().trim()
         BlockRegistry[correctedName] = block
         BlockItemsRegistry[correctedName + "_item"] =
@@ -39,12 +39,10 @@ object ModIdBlocks {
         BlockRegistry.forEach {
             Registry.register(Registry.BLOCK, Identifier(MainFile.MOD_ID, it.key), it.value)
         }
-        fun registerBlockItems() {
-            BlockItemsRegistry.forEach {
-                Registry.register(Registry.ITEM, Identifier(MainFile.MOD_ID, it.key), it.value)
 
-            }
+        BlockItemsRegistry.forEach {
+            Registry.register(Registry.ITEM, Identifier(MainFile.MOD_ID, it.key), it.value)
+
         }
-        registerBlockItems()
     }
 }

--- a/src/main/kotlin/org/llamarama/petty/items/PettyItems.kt
+++ b/src/main/kotlin/org/llamarama/petty/items/PettyItems.kt
@@ -8,7 +8,7 @@ import net.minecraft.item.ItemGroup
 import net.minecraft.util.Identifier
 import net.minecraft.util.registry.Registry
 
-object ModIdItems {
+object PettyItems {
     private val ItemRegistry = linkedMapOf<String, Item>()
 
     val COOL_ITEM: Item
@@ -20,7 +20,7 @@ object ModIdItems {
         COOL_ITEM = addItem("coolitem", Item(Item.Settings().maxCount(64).group(ItemGroup.MISC)))
     }
 
-    private fun <I: Item> addItem(name: String, item: I): I {
+    private fun  addItem(name: String, item: Item): Item {
         val correctedName = name.replace(" ", "").lowercase().trim()
         ItemRegistry[correctedName] = item
         return item

--- a/src/main/kotlin/org/llamarama/petty/worldgen/decorators/DecoratorTypes.kt
+++ b/src/main/kotlin/org/llamarama/petty/worldgen/decorators/DecoratorTypes.kt
@@ -1,0 +1,9 @@
+package org.llamarama.petty.worldgen.decorators
+
+import net.minecraft.world.gen.treedecorator.TreeDecoratorType
+import org.llamarama.petty.mixins.TreeDecoratorTypeMixin
+
+object DecoratorTypes {
+    val TREE_HOLE_DECORATOR: TreeDecoratorType<TreeHoleDecorator> =
+        TreeDecoratorTypeMixin.callRegister("tree_hole_decorator", codec)
+}

--- a/src/main/kotlin/org/llamarama/petty/worldgen/decorators/TreeHoleDecorator.kt
+++ b/src/main/kotlin/org/llamarama/petty/worldgen/decorators/TreeHoleDecorator.kt
@@ -1,0 +1,56 @@
+package org.llamarama.petty.worldgen.decorators
+
+import com.mojang.serialization.Codec
+import net.minecraft.block.BlockState
+import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Direction
+import net.minecraft.world.TestableWorld
+import net.minecraft.world.gen.feature.Feature
+import net.minecraft.world.gen.treedecorator.TreeDecorator
+import net.minecraft.world.gen.treedecorator.TreeDecoratorType
+import org.llamarama.petty.blocks.PettyBlocks
+import java.util.*
+import java.util.function.BiConsumer
+
+val codec = Codec.unit { INSTANCE }
+private val INSTANCE = TreeHoleDecorator()
+private val FACE_DIRECTION = Direction.SOUTH
+
+class TreeHoleDecorator() : TreeDecorator() {
+
+    override fun getType(): TreeDecoratorType<*> {
+        return DecoratorTypes.TREE_HOLE_DECORATOR
+    }
+
+    /**
+     * 5% chance
+     */
+    override fun generate(
+        world: TestableWorld?,
+        replacer: BiConsumer<BlockPos, BlockState>?,
+        random: Random?,
+        logPositions: MutableList<BlockPos>?,
+        leavesPositions: MutableList<BlockPos>?,
+    ) {
+        // do nothing if the random number does not fulfill the 5% chance
+        // In the 2 tests I made so far this was why too high
+        if (random!!.nextInt() >= 5) return
+
+        // from BeehiveTreeDecorator
+        val i =
+            if (!leavesPositions!!.isEmpty())
+                (leavesPositions[0].y - 1).coerceAtLeast(logPositions!![0].y + 1)
+            else
+                (logPositions!![0].y + 1 + random.nextInt(3)).coerceAtMost(logPositions[logPositions.size - 1].y)
+        logPositions.stream().filter { pos: BlockPos -> pos.y == i }
+            // filter out the positions which don't have air in front of them
+            .filter { Feature.isAir(world, it.offset(FACE_DIRECTION)) }
+            // then find the first one
+            .findFirst()
+            // then map over the optional replacing it with a tree hole block
+            .map { pos: BlockPos ->
+                replacer!!.accept(pos, PettyBlocks.COOL_BLOCK.defaultState)
+                pos
+            }
+    }
+}

--- a/src/main/resources/modid.mixins.json
+++ b/src/main/resources/modid.mixins.json
@@ -1,11 +1,14 @@
 {
   "required": true,
-  "package": "com.username.modid.mixins",
+  "package": "org.llamarama.petty.mixins",
   "compatibilityLevel": "JAVA_17",
   "injectors": {
     "defaultRequire": 1
   },
-  "mixins": [],
+  "mixins": [
+    "ConfiguredFeaturesMixin",
+    "TreeDecoratorTypeMixin"
+  ],
   "client": [],
   "server": []
 }


### PR DESCRIPTION
Currently this is only a proof of concept.
The main goal is to add treeholes to trees of any kind.
Birds can live in those treeholes similarity to bees in beehives.

- [  ] The amount of treeholes is way too high at the moment.
- [  ] Treeholes dont have a dedicated block
- [  ] Treeholes dont have a texture
- [  ] Birds cannot live in treeholes
- [  ] Treeholes spawn too often
- [  ] Treeholes are currently replacing beehives (I added this for debug purposes)

`org.llamarama.petty.worldgen.decorators.DecoratorTypes` is currently an object (singleton class),
but I think this is not needed, top-level declarations should work, I was unable to actually
get those to work though. I used DecoratorTypesKt as reference (as it was also in the bytecode)
but the compiler wasn't happy with it.

