### PR TITLE
Fix namespaces for items, blocks and modid

### DIFF
--- a/src/main/kotlin/org/llamarama/petty/MainFile.kt
+++ b/src/main/kotlin/org/llamarama/petty/MainFile.kt
@@ -1,9 +1,11 @@
+@file:JvmName("PettyMain")
 package org.llamarama.petty
 
-import org.llamarama.petty.blocks.PettyBlocks
-import org.llamarama.petty.items.PettyItems
 import net.fabricmc.api.ModInitializer
+import org.llamarama.petty.blocks.registerBlocks
+import org.llamarama.petty.items.registerItems
 
+const val MOD_ID = "petty"
 
 /**
  * Main File
@@ -13,11 +15,10 @@ import net.fabricmc.api.ModInitializer
  */
 @Suppress("UNUSED")
 object MainFile : ModInitializer {
-    const val MOD_ID = "petty"
 
 
     override fun onInitialize() {
-        PettyBlocks.registerBlocks()
-        PettyItems.registerItems()
+        registerBlocks()
+        registerItems()
     }
 }

--- a/src/main/kotlin/org/llamarama/petty/blocks/PettyBlocks.kt
+++ b/src/main/kotlin/org/llamarama/petty/blocks/PettyBlocks.kt
@@ -1,8 +1,8 @@
+@file:JvmName("PettyBlocks")
 @file:Suppress("SameParameterValue", "MemberVisibilityCanBePrivate")
 
 package org.llamarama.petty.blocks
 
-import org.llamarama.petty.MainFile
 import net.minecraft.block.AbstractBlock
 import net.minecraft.block.Block
 import net.minecraft.block.Blocks
@@ -11,37 +11,30 @@ import net.minecraft.item.Item
 import net.minecraft.item.ItemGroup
 import net.minecraft.util.Identifier
 import net.minecraft.util.registry.Registry
+import org.llamarama.petty.MOD_ID
 
-object PettyBlocks {
-    private val BlockItemsRegistry = linkedMapOf<String, Item>()
-    private val BlockRegistry = linkedMapOf<String, Block>()
+private val BlockItemsRegistry = linkedMapOf<String, Item>()
+private val BlockRegistry = linkedMapOf<String, Block>()
 
-    val COOL_BLOCK: Block
+/**
+ * Register blocks under here.
+ */
+val COOL_BLOCK = addBlock("coolblock", Block(AbstractBlock.Settings.copy(Blocks.STONE)))
 
-    /**
-     * Register blocks in here.
-     * [net.minecraft.item.BlockItem]'s gets added automatically (but can't be referenced atm).
-     * If you wish to change the settings of the BlockItem implement your own methods for it.
-     */
-    init {
-        COOL_BLOCK = addBlock("coolblock", Block(AbstractBlock.Settings.copy(Blocks.STONE)))
+private fun addBlock(name: String, block: Block): Block {
+    val correctedName = name.replace(" ", "").lowercase().trim()
+    BlockRegistry[correctedName] = block
+    BlockItemsRegistry[correctedName + "_item"] =
+        (BlockItem(block, Item.Settings().maxCount(64).group(ItemGroup.MISC)))
+    return block
+}
+
+fun registerBlocks() {
+    BlockRegistry.forEach { (name, block) ->
+        Registry.register(Registry.BLOCK, Identifier(MOD_ID, name), block)
     }
+    BlockItemsRegistry.forEach { (name, item) ->
+        Registry.register(Registry.ITEM, Identifier(MOD_ID, name), item)
 
-    private fun addBlock(name: String, block: Block): Block {
-        val correctedName = name.replace(" ", "").lowercase().trim()
-        BlockRegistry[correctedName] = block
-        BlockItemsRegistry[correctedName + "_item"] =
-            (BlockItem(block, Item.Settings().maxCount(64).group(ItemGroup.MISC)))
-        return block
-    }
-
-    fun registerBlocks() {
-        BlockRegistry.forEach { (name, block) ->
-            Registry.register(Registry.BLOCK, Identifier(MainFile.MOD_ID, name), block)
-        }
-        BlockItemsRegistry.forEach { (name, item) ->
-            Registry.register(Registry.ITEM, Identifier(MainFile.MOD_ID, name), item)
-
-        }
     }
 }

--- a/src/main/kotlin/org/llamarama/petty/items/PettyItems.kt
+++ b/src/main/kotlin/org/llamarama/petty/items/PettyItems.kt
@@ -1,34 +1,30 @@
+@file:JvmName("PettyItems")
 @file:Suppress("SameParameterValue", "MemberVisibilityCanBePrivate")
 
 package org.llamarama.petty.items
 
-import org.llamarama.petty.MainFile
 import net.minecraft.item.Item
 import net.minecraft.item.ItemGroup
 import net.minecraft.util.Identifier
 import net.minecraft.util.registry.Registry
+import org.llamarama.petty.MOD_ID
 
-object PettyItems {
-    private val ItemRegistry = linkedMapOf<String, Item>()
+private val ItemRegistry = linkedMapOf<String, Item>()
 
-    val COOL_ITEM: Item
 
-    /**
-     * Register [net.minecraft.item.Item]'s in here.
-     */
-    init {
-        COOL_ITEM = addItem("coolitem", Item(Item.Settings().maxCount(64).group(ItemGroup.MISC)))
-    }
+/**
+ * Register [net.minecraft.item.Item]'s under here.
+ */
+val COOL_ITEM = addItem("coolitem", Item(Item.Settings().maxCount(64).group(ItemGroup.MISC)))
 
-    private fun addItem(name: String, item: Item): Item {
-        val correctedName = name.replace(" ", "").lowercase().trim()
-        ItemRegistry[correctedName] = item
-        return item
-    }
+private fun addItem(name: String, item: Item): Item {
+    val correctedName = name.replace(" ", "").lowercase().trim()
+    ItemRegistry[correctedName] = item
+    return item
+}
 
-    fun registerItems() {
-        ItemRegistry.forEach { (name, item) ->
-            Registry.register(Registry.ITEM, Identifier(MainFile.MOD_ID, name), item)
-        }
+fun registerItems() {
+    ItemRegistry.forEach { (name, item) ->
+        Registry.register(Registry.ITEM, Identifier(MOD_ID, name), item)
     }
 }


### PR DESCRIPTION
The following three are now top-level in Kotlin.

1. MOD_ID
2. Items
3. Blocks
